### PR TITLE
Change protection level of 'maxConcurrentTaskCount' to open

### DIFF
--- a/Sources/Overdrive/TaskQueue.swift
+++ b/Sources/Overdrive/TaskQueue.swift
@@ -153,7 +153,7 @@ open class TaskQueue {
     
     /// The maximum number of tasks that can be executed at the same time
     /// concurrently.
-    var maxConcurrentTaskCount: Int {
+    open var maxConcurrentTaskCount: Int {
         get { return operationQueue.maxConcurrentOperationCount }
         
         set(newCount) {


### PR DESCRIPTION
Without this change, the compiler throws an error when trying to set
'maxConcurrentTaskCount' in e.g. an application that uses Overdrive:
'maxConcurrentTaskCount' is inaccessible due to 'internal' protection
level