### PR TITLE
fixed state inconstancy when cancelling task

### DIFF
--- a/Sources/Overdrive/Task.swift
+++ b/Sources/Overdrive/Task.swift
@@ -588,9 +588,13 @@ open class Task<T>: TaskBase {
         case .initialized:
             return isCancelled
         case .pending:
-            guard !isCancelled else {
-				self.state = .ready
-                return true
+            if isCancelled {
+				let ready = super.isReady
+				if ready
+				{
+					self.state = .ready
+				}
+                return ready
             }
             
             if super.isReady {

--- a/Sources/Overdrive/Task.swift
+++ b/Sources/Overdrive/Task.swift
@@ -589,6 +589,7 @@ open class Task<T>: TaskBase {
             return isCancelled
         case .pending:
             guard !isCancelled else {
+				self.state = .ready
                 return true
             }
             

--- a/Sources/Overdrive/Task.swift
+++ b/Sources/Overdrive/Task.swift
@@ -590,8 +590,7 @@ open class Task<T>: TaskBase {
         case .pending:
             if isCancelled {
                 let ready = super.isReady
-                if ready
-                {
+                if ready {
                     self.state = .ready
                 }
                 return ready

--- a/Sources/Overdrive/Task.swift
+++ b/Sources/Overdrive/Task.swift
@@ -589,11 +589,11 @@ open class Task<T>: TaskBase {
             return isCancelled
         case .pending:
             if isCancelled {
-				let ready = super.isReady
-				if ready
-				{
-					self.state = .ready
-				}
+                let ready = super.isReady
+                if ready
+                {
+                    self.state = .ready
+                }
                 return ready
             }
             

--- a/Sources/Overdrive/TaskQueue.swift
+++ b/Sources/Overdrive/TaskQueue.swift
@@ -195,10 +195,9 @@ open class TaskQueue {
      */
     open func add<T>(task: Task<T>) {
         if !task.contains(observer: FinishBlockObserver.self) {
-            unowned let observedTask = task
-            task.add(observer: FinishBlockObserver { [weak self] in
+            task.add(observer: FinishBlockObserver { [weak self, unowned task] in
                 if let queue = self {
-                    queue.delegate?.didFinish(task: observedTask, inQueue: queue)
+                    queue.delegate?.didFinish(task: task, inQueue: queue)
                 }
             })
         }

--- a/Sources/Overdrive/TaskQueue.swift
+++ b/Sources/Overdrive/TaskQueue.swift
@@ -195,9 +195,10 @@ open class TaskQueue {
      */
     open func add<T>(task: Task<T>) {
         if !task.contains(observer: FinishBlockObserver.self) {
+            unowned let observedTask = task
             task.add(observer: FinishBlockObserver { [weak self] in
                 if let queue = self {
-                    queue.delegate?.didFinish(task: task, inQueue: queue)
+                    queue.delegate?.didFinish(task: observedTask, inQueue: queue)
                 }
             })
         }

--- a/Tests/OverdriveTests/DependencyTests.swift
+++ b/Tests/OverdriveTests/DependencyTests.swift
@@ -108,34 +108,33 @@ class DependencyTests: TestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 	
-	func testCancellationOfDependentTask()
-	{
-		let queue = TaskQueue()
-		let delay: TimeInterval = 1.0
-		let delayTask = TestCaseDelayedTask(withResult: .value(()), delay: delay)
-		
-		let equalExpectation = expectation(description: "value is equal to initial value")
-		let initialValue = 0
-		var value = initialValue
-		
-		let modifyTask = InlineTask({
-			value = 1
-		})
-		modifyTask.add(dependency: delayTask)
-		
-		let checkTask = InlineTask({
-			XCTAssert(value == initialValue)
-			equalExpectation.fulfill()
-		})
-		checkTask.add(dependency: modifyTask)
-		
-		queue.add(task: delayTask)
-		queue.add(task: modifyTask)
-		queue.add(task: checkTask)
-		
-		modifyTask.cancel()
-		
-		waitForExpectations(timeout: delay + 0.5)
-	}
-    
+    func testCancellationOfDependentTask()
+    {
+        let queue = TaskQueue()
+        let delay: TimeInterval = 1.0
+        let delayTask = TestCaseDelayedTask(withResult: .value(()), delay: delay)
+
+        let equalExpectation = expectation(description: "value is equal to initial value")
+        let initialValue = 0
+        var value = initialValue
+
+        let modifyTask = InlineTask({
+            value = 1
+        })
+        modifyTask.add(dependency: delayTask)
+
+        let checkTask = InlineTask({
+            XCTAssert(value == initialValue)
+            equalExpectation.fulfill()
+        })
+        checkTask.add(dependency: modifyTask)
+
+        queue.add(task: delayTask)
+        queue.add(task: modifyTask)
+        queue.add(task: checkTask)
+        
+        modifyTask.cancel()
+        
+        waitForExpectations(timeout: delay + 0.5)
+    }
 }

--- a/Tests/OverdriveTests/DependencyTests.swift
+++ b/Tests/OverdriveTests/DependencyTests.swift
@@ -107,5 +107,35 @@ class DependencyTests: TestCase {
         
         waitForExpectations(timeout: 1, handler: nil)
     }
+	
+	func testCancellationOfDependentTask()
+	{
+		let queue = TaskQueue()
+		let delay: TimeInterval = 1.0
+		let delayTask = TestCaseDelayedTask(withResult: .value(()), delay: delay)
+		
+		let equalExpectation = expectation(description: "value is equal to initial value")
+		let initialValue = 0
+		var value = initialValue
+		
+		let modifyTask = InlineTask({
+			value = 1
+		})
+		modifyTask.add(dependency: delayTask)
+		
+		let checkTask = InlineTask({
+			XCTAssert(value == initialValue)
+			equalExpectation.fulfill()
+		})
+		checkTask.add(dependency: modifyTask)
+		
+		queue.add(task: delayTask)
+		queue.add(task: modifyTask)
+		queue.add(task: checkTask)
+		
+		modifyTask.cancel()
+		
+		waitForExpectations(timeout: delay + 0.5)
+	}
     
 }

--- a/Tests/OverdriveTests/DependencyTests.swift
+++ b/Tests/OverdriveTests/DependencyTests.swift
@@ -108,8 +108,7 @@ class DependencyTests: TestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 	
-    func testCancellationOfDependentTask()
-    {
+    func testCancellationOfDependentTask() {
         let queue = TaskQueue()
         let delay: TimeInterval = 1.0
         let delayTask = TestCaseDelayedTask(withResult: .value(()), delay: delay)

--- a/Tests/OverdriveTests/TestCase.swift
+++ b/Tests/OverdriveTests/TestCase.swift
@@ -33,6 +33,30 @@ class TestCaseTask<T>: Task<T> {
     }
 }
 
+/// Special `TestCaseTask<T>` subclass that is used in test enviroment
+/// in cases where task should finished after a predefinied period of time
+/// with result should be defined at initialization stage.
+class TestCaseDelayedTask<T>: TestCaseTask<T> {
+    
+    /// Test result
+    let delay: TimeInterval
+    
+    /// Create new instance with specified result
+    ///
+    /// - Parameter result: Any `Result<T>`
+    init(withResult result: Result<T>, delay: TimeInterval) {
+        self.delay = delay
+		super.init(withResult: result)
+    }
+    
+    override func run() {
+        DispatchQueue.main.asyncAfter(
+            deadline: DispatchTime.now() + Double(Int64(self.delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: {
+                self.finish(with: self.testResult)
+        })
+    }
+}
+
 /// Returns a `Task<T>` instance that will finish with
 /// specified result
 ///

--- a/Tests/OverdriveTests/TestCase.swift
+++ b/Tests/OverdriveTests/TestCase.swift
@@ -37,18 +37,18 @@ class TestCaseTask<T>: Task<T> {
 /// in cases where task should finished after a predefinied period of time
 /// with result should be defined at initialization stage.
 class TestCaseDelayedTask<T>: TestCaseTask<T> {
-    
+
     /// Test result
     let delay: TimeInterval
-    
+
     /// Create new instance with specified result
     ///
     /// - Parameter result: Any `Result<T>`
     init(withResult result: Result<T>, delay: TimeInterval) {
         self.delay = delay
-		super.init(withResult: result)
+        super.init(withResult: result)
     }
-    
+
     override func run() {
         DispatchQueue.main.asyncAfter(
             deadline: DispatchTime.now() + Double(Int64(self.delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: {


### PR DESCRIPTION
I encountered a problem when cancelling a task that's in pending state because it has a dependency on another task that's still running. As you just returned true for isReady property when in pending state start() is called on the cancelled task calling moveToFinishedState() leading to an illegal state transition from .pending to .finished. I solved this issue by setting the task's state to .ready as soon as super.isReady returns true.